### PR TITLE
Make timezones optional

### DIFF
--- a/src/Model/Calendar.php
+++ b/src/Model/Calendar.php
@@ -201,8 +201,12 @@ class Calendar
     /**
      * @param \DateTimeZone $timezone
      * @return \Jsvrcek\ICS\Model\Calendar
+     *
+     * @todo for PHP 7.1, we could also make this type-hint nullable
+     * For 7.0 compatibility, the default value must suffice.
+     *
      */
-    public function setTimezone(\DateTimeZone $timezone)
+    public function setTimezone(\DateTimeZone $timezone = null)
     {
         $this->timezone = $timezone;
         return $this;


### PR DESCRIPTION
This pull request will allow us to have nullable timezones which then don't output into feeds, and should make my related application fix (https://gitlab.opusoneinteractive.com/agency_admin/admin/merge_requests/2933) work properly.

If we want to be fussy about it, I should also write a test for this, but right now at least I am comfortable relegating that for a follow-up when we upstream the change (if we upstream the change).

